### PR TITLE
Fix package name errors due to capitalization mismatch

### DIFF
--- a/src/main/java/coms/w4156/moviewishlist/Controllers/DummyController.java
+++ b/src/main/java/coms/w4156/moviewishlist/Controllers/DummyController.java
@@ -1,6 +1,6 @@
-package coms.w4156.moviewishlist.Controllers;
+package coms.w4156.moviewishlist.controllers;
 
-import coms.w4156.moviewishlist.Services.DummyService;
+import coms.w4156.moviewishlist.services.DummyService;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/coms/w4156/moviewishlist/Controllers/StreamingController.java
+++ b/src/main/java/coms/w4156/moviewishlist/Controllers/StreamingController.java
@@ -1,6 +1,6 @@
-package coms.w4156.moviewishlist.Controllers;
+package coms.w4156.moviewishlist.controllers;
 
-import coms.w4156.moviewishlist.Services.WatchModeService;
+import coms.w4156.moviewishlist.services.WatchModeService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;

--- a/src/main/java/coms/w4156/moviewishlist/Controllers/package-info.java
+++ b/src/main/java/coms/w4156/moviewishlist/Controllers/package-info.java
@@ -2,4 +2,4 @@
  * This package contains the controllers for this project. The controllers are
  * used to define endpoints.
  */
-package coms.w4156.moviewishlist.Controllers;
+package coms.w4156.moviewishlist.controllers;

--- a/src/main/java/coms/w4156/moviewishlist/Services/DummyService.java
+++ b/src/main/java/coms/w4156/moviewishlist/Services/DummyService.java
@@ -1,4 +1,4 @@
-package coms.w4156.moviewishlist.Services;
+package coms.w4156.moviewishlist.services;
 
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/coms/w4156/moviewishlist/Services/Source.java
+++ b/src/main/java/coms/w4156/moviewishlist/Services/Source.java
@@ -1,4 +1,4 @@
-package coms.w4156.moviewishlist.Services;
+package coms.w4156.moviewishlist.services;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/coms/w4156/moviewishlist/Services/WatchModeService.java
+++ b/src/main/java/coms/w4156/moviewishlist/Services/WatchModeService.java
@@ -1,4 +1,4 @@
-package coms.w4156.moviewishlist.Services;
+package coms.w4156.moviewishlist.services;
 
 import coms.w4156.moviewishlist.utils.Config;
 import lombok.Getter;

--- a/src/main/java/coms/w4156/moviewishlist/Services/package-info.java
+++ b/src/main/java/coms/w4156/moviewishlist/Services/package-info.java
@@ -1,4 +1,4 @@
 /**
  * This package is used for the @Service objects.
  */
-package coms.w4156.moviewishlist.Services;
+package coms.w4156.moviewishlist.services;

--- a/src/test/java/coms/w4156/moviewishlist/DummyTests.java
+++ b/src/test/java/coms/w4156/moviewishlist/DummyTests.java
@@ -1,7 +1,7 @@
 package coms.w4156.moviewishlist;
 
-import coms.w4156.moviewishlist.Controllers.DummyController;
-import coms.w4156.moviewishlist.Services.DummyService;
+import coms.w4156.moviewishlist.controllers.DummyController;
+import coms.w4156.moviewishlist.services.DummyService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/src/test/java/coms/w4156/moviewishlist/serviceTests/WatchModeServiceTests.java
+++ b/src/test/java/coms/w4156/moviewishlist/serviceTests/WatchModeServiceTests.java
@@ -1,7 +1,7 @@
 package coms.w4156.moviewishlist.serviceTests;
 
-import coms.w4156.moviewishlist.Services.Source;
-import coms.w4156.moviewishlist.Services.WatchModeService;
+import coms.w4156.moviewishlist.services.Source;
+import coms.w4156.moviewishlist.services.WatchModeService;
 import coms.w4156.moviewishlist.utils.Config;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This just fixes a whole bunch of styles errors I got because the package names didn't match the folder names.

e.g. The folder name was `services` but the package name was `Services`