### PR TITLE
Fix autowire issue

### DIFF
--- a/src/main/java/coms/w4156/moviewishlist/MovieWishlistApplication.java
+++ b/src/main/java/coms/w4156/moviewishlist/MovieWishlistApplication.java
@@ -2,9 +2,7 @@ package coms.w4156.moviewishlist;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
-@ComponentScan
 @SpringBootApplication
 public class MovieWishlistApplication {
 

--- a/src/test/java/coms/w4156/moviewishlist/DummyTests.java
+++ b/src/test/java/coms/w4156/moviewishlist/DummyTests.java
@@ -30,15 +30,6 @@ public class DummyTests {
     @MockBean
     DummyService ds;
 
-    @MockBean
-    MovieService ms;
-
-    @MockBean
-    UserService us;
-
-    @MockBean
-    WishlistService wls;
-
     @Test
     public void numTest() throws Exception {
         this.mockMvc.perform(get("/num"))

--- a/src/test/java/coms/w4156/moviewishlist/DummyTests.java
+++ b/src/test/java/coms/w4156/moviewishlist/DummyTests.java
@@ -2,9 +2,6 @@ package coms.w4156.moviewishlist;
 
 import coms.w4156.moviewishlist.controllers.DummyController;
 import coms.w4156.moviewishlist.services.DummyService;
-import coms.w4156.moviewishlist.services.MovieService;
-import coms.w4156.moviewishlist.services.UserService;
-import coms.w4156.moviewishlist.services.WishlistService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/src/test/java/coms/w4156/moviewishlist/DummyTests.java
+++ b/src/test/java/coms/w4156/moviewishlist/DummyTests.java
@@ -2,6 +2,9 @@ package coms.w4156.moviewishlist;
 
 import coms.w4156.moviewishlist.controllers.DummyController;
 import coms.w4156.moviewishlist.services.DummyService;
+import coms.w4156.moviewishlist.services.MovieService;
+import coms.w4156.moviewishlist.services.UserService;
+import coms.w4156.moviewishlist.services.WishlistService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,6 +29,15 @@ public class DummyTests {
 
     @MockBean
     DummyService ds;
+
+    @MockBean
+    MovieService ms;
+
+    @MockBean
+    UserService us;
+
+    @MockBean
+    WishlistService wls;
 
     @Test
     public void numTest() throws Exception {


### PR DESCRIPTION
Looks like this @ComponentScan annotation is what required the inclusion of every service in our individual controller tests. This isn't super scalable and it breaks isolation so I don't think this is desirable. Furthermore, I am able to run the application locally with no issue without this annotation.

@ben-natan It looks like you added this line in order to make the API work, is there any reason you could see why deleting this line could have unintended consequences? 